### PR TITLE
Fix for SDFFetcher for jobs without sdfCopied attr

### DIFF
--- a/lib/hgcs/agents.py
+++ b/lib/hgcs/agents.py
@@ -228,7 +228,7 @@ class SDFFetcher(ThreadBase):
         ]
 
     requirements = (
-                    'sdfCopied == 0 '
+                    '(isUndefined(sdfCopied) || sdfCopied == 0) '
                     '&& isString(sdfPath) '
                 )
 


### PR DESCRIPTION
On local schedd installation on harvester-pilot2.cern.ch jobs are created without sdfCopied attribute, so HGCS SDFFetcher was not doing anything